### PR TITLE
add caching to token validator

### DIFF
--- a/src/main/java/st/ratpack/auth/AuthModule.java
+++ b/src/main/java/st/ratpack/auth/AuthModule.java
@@ -2,7 +2,6 @@ package st.ratpack.auth;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Provides;
-import com.google.inject.Scopes;
 import com.google.inject.Singleton;
 import ratpack.guice.ConfigurableModule;
 import ratpack.http.client.HttpClient;
@@ -25,6 +24,7 @@ public class AuthModule extends ConfigurableModule<AuthModule.Config> {
 		URI host;
 		String user;
 		String password;
+		Long ttl;
 
 		public URI getHost() {
 			return host;
@@ -49,6 +49,10 @@ public class AuthModule extends ConfigurableModule<AuthModule.Config> {
 		public void setPassword(String password) {
 			this.password = password;
 		}
+
+		public Long getTtl() { return ttl; }
+
+		public void setTtl(Long ttl) { this.ttl = ttl; }
 	}
 
 }

--- a/src/main/java/st/ratpack/auth/TokenValidator.java
+++ b/src/main/java/st/ratpack/auth/TokenValidator.java
@@ -1,6 +1,5 @@
 package st.ratpack.auth;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import ratpack.exec.Promise;
 
 import java.util.Optional;

--- a/src/main/java/st/ratpack/auth/handler/BearerTokenAuthHandler.java
+++ b/src/main/java/st/ratpack/auth/handler/BearerTokenAuthHandler.java
@@ -1,6 +1,5 @@
 package st.ratpack.auth.handler;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import ratpack.exec.Promise;
 import ratpack.handling.Context;


### PR DESCRIPTION
this is an alternate to https://github.com/SmartThingsOSS/ratpack-bearer-auth/pull/12 with the cache in the default validator only on success
