### PR TITLE
Make cache lookups atomic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ if (!JavaVersion.current().java8Compatible) {
 }
 
 task wrapper(type: Wrapper) {
-  gradleVersion = "2.7"
+  gradleVersion = "2.10"
 }
 
 group = "smartthings"
@@ -26,6 +26,7 @@ version = rootProject.file('version.txt').text.trim()
 apply plugin: "base"
 apply plugin: "groovy"
 apply plugin: "jacoco"
+apply plugin: "idea"
 apply from: file('gradle/publishing.gradle')
 
 sourceCompatibility = "1.8"
@@ -47,7 +48,7 @@ dependencies {
   compile "io.ratpack:ratpack-guice:${ratpackVersion}"
 
 	//Caching Impl
-	compile 'com.github.ben-manes.caffeine:caffeine:1.3.3'
+	compile 'com.github.ben-manes.caffeine:caffeine:2.1.0'
 
   testCompile "org.codehaus.groovy:groovy-all:${groovyVersion}"
   testCompile "io.ratpack:ratpack-groovy-test:${ratpackVersion}"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-bin.zip

--- a/src/main/java/st/ratpack/auth/CachingTokenValidator.java
+++ b/src/main/java/st/ratpack/auth/CachingTokenValidator.java
@@ -36,7 +36,11 @@ public class CachingTokenValidator implements TokenValidator {
 		Promise<Optional<OAuthToken>>
 				promiseOAuthToken = upstreamValidator.validate(token).cache();
 
-		promiseOAuthToken.then(o -> logger.trace("PUTTING: {}", o));
+		promiseOAuthToken
+				.onError(e -> cache.invalidate(token))
+				.map(o -> o.orElse(null))
+				.onNull(() -> cache.invalidate(token))
+				.then(o -> logger.trace("PUTTING: {}", o));
 
 		return promiseOAuthToken;
 	}

--- a/src/main/java/st/ratpack/auth/CachingTokenValidator.java
+++ b/src/main/java/st/ratpack/auth/CachingTokenValidator.java
@@ -1,18 +1,18 @@
 package st.ratpack.auth;
 
+import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ratpack.exec.Promise;
-import com.github.benmanes.caffeine.cache.Cache;
 
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 public class CachingTokenValidator implements TokenValidator {
 
-	TokenValidator upstreamValidator;
-	Cache<String, Promise<Optional<OAuthToken>>> cache;
+	private final TokenValidator upstreamValidator;
+	private final Cache<String, Promise<Optional<OAuthToken>>> cache;
 	private static Logger logger = LoggerFactory.getLogger(CachingTokenValidator.class);
 
 	public CachingTokenValidator(TokenValidator upstreamValidator) {
@@ -21,39 +21,23 @@ public class CachingTokenValidator implements TokenValidator {
 		cache = Caffeine.<String, Promise<Optional<OAuthToken>>>newBuilder()
 			.maximumSize(10000L)
 			.expireAfterWrite(5L, TimeUnit.MINUTES)
+			.recordStats()
 			//			.executor(Execution.current().getEventLoop())  Don't do this it makes Ratpack hang.
 			.build();
 	}
 
 	@Override
 	public Promise<Optional<OAuthToken>> validate(String token) {
-		Promise<Optional<OAuthToken>> promiseOAuthToken = cache.getIfPresent(token);
+		return cache.get(token, this::loadCache);
+	}
 
-		if (promiseOAuthToken == null) {
-			//Cache miss use the upstream validator
-			logger.trace("Cache MISS: " + token);
-			promiseOAuthToken = upstreamValidator.validate(token);
+	private Promise<Optional<OAuthToken>> loadCache(String token) {
+		logger.trace("Cache MISS: {}", token);
+		//Make sure we only call the validate on the upstream once
+		Promise<Optional<OAuthToken>>
+				promiseOAuthToken = upstreamValidator.validate(token).cache();
 
-			//Make sure we only call the validate on the upstream once
-			promiseOAuthToken = promiseOAuthToken.cache();
-
-			promiseOAuthToken.then(optionalOAuth -> {
-				logger.trace("PUTTING: " + optionalOAuth);
-				cache.put(token, Promise.value(optionalOAuth));
-			});
-
-			//TODO The wiretap is cleaner but doesn't currently seem to work due to upstream bug
-			//Wiretap the promise so we can cache any successful results
-			//			promiseOAuthToken.wiretap(optionalResult -> {
-			//				logger.trace("Wiretap called");
-			//				if (optionalResult.isSuccess()) {
-			//					logger.trace("Caching promise value");
-			//					cache.put(token, Promise.value(optionalResult.getValue()));
-			//				}
-			//			});
-		} else {
-			logger.trace("CACHE HIT: " + token);
-		}
+		promiseOAuthToken.then(o -> logger.trace("PUTTING: {}", o));
 
 		return promiseOAuthToken;
 	}

--- a/src/main/java/st/ratpack/auth/TokenValidator.java
+++ b/src/main/java/st/ratpack/auth/TokenValidator.java
@@ -1,6 +1,5 @@
 package st.ratpack.auth;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import ratpack.exec.Promise;
 
 import java.util.Optional;

--- a/src/main/java/st/ratpack/auth/springsec/SpringSecCheckTokenValidator.java
+++ b/src/main/java/st/ratpack/auth/springsec/SpringSecCheckTokenValidator.java
@@ -46,7 +46,7 @@ public class SpringSecCheckTokenValidator implements TokenValidator {
 			});
 		});
 
-		return Promise.of(downstream -> {
+		return Promise.of(downstream ->
 			resp.onError(t -> {
 				logger.error("Failed to check auth token.", t);
 				downstream.success(Optional.<OAuthToken>empty());
@@ -83,9 +83,8 @@ public class SpringSecCheckTokenValidator implements TokenValidator {
 						downstream.error(ex);
 					}
 				}
-			});
-
-		});
+			})
+		);
 	}
 
 	private String buildBasicAuthHeader(String user, String password) {


### PR DESCRIPTION
- Make use of Caffeine's  "computeIfAbsent" to avoid concurrent token validations for a given token.
- Upgrade Gradle 2.7 -> 2.10
