### PR TITLE
Add NoOpTokenValidator for use in testing token authenticated endpoints

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,11 +46,11 @@ dependencies {
   compile "org.slf4j:slf4j-api:${slf4jVersion}"
   compile "io.ratpack:ratpack-core:${ratpackVersion}"
   compile "io.ratpack:ratpack-guice:${ratpackVersion}"
+  compile "org.codehaus.groovy:groovy-all:${groovyVersion}"
 
-	//Caching Impl
-	compile 'com.github.ben-manes.caffeine:caffeine:2.1.0'
+  //Caching Impl
+  compile 'com.github.ben-manes.caffeine:caffeine:2.1.0'
 
-  testCompile "org.codehaus.groovy:groovy-all:${groovyVersion}"
   testCompile "io.ratpack:ratpack-groovy-test:${ratpackVersion}"
   testCompile 'org.spockframework:spock-core:1.0-groovy-2.4'
   testRuntime 'cglib:cglib-nodep:2.2.2'

--- a/src/main/groovy/st/fixture/NoOpTokenValidator.groovy
+++ b/src/main/groovy/st/fixture/NoOpTokenValidator.groovy
@@ -1,0 +1,21 @@
+package st.fixture
+
+import ratpack.exec.Promise
+import st.ratpack.auth.OAuthToken
+import st.ratpack.auth.TokenValidator
+import st.ratpack.auth.User
+
+/**
+ * Used to circumvent token validation during testing.
+ */
+class NoOpTokenValidator implements TokenValidator {
+
+	@Override
+	Promise<Optional<OAuthToken>> validate(String token) {
+		if (token.contains("service")) {
+			return Promise.value(Optional.of(new OAuthToken(Optional.<User> empty(), ['service'] as Set<String>, 'fake client')))
+		}
+		def user = Optional.of(new User("fakeUser", ["ROLE_FAKE"] as Set<String>))
+		return Promise.value(Optional.of(new OAuthToken(user, ['mobile'] as Set<String>, 'fake client')))
+	}
+}


### PR DESCRIPTION
I have a need for this in a new service and don't want to duplicate it from existing services.
