### PR TITLE
DEVTOOLS-683: Add authToken string to OAuthToken class

### DIFF
--- a/ratpack-bearer-auth-test/src/main/groovy/st/fixture/NoOpTokenValidator.groovy
+++ b/ratpack-bearer-auth-test/src/main/groovy/st/fixture/NoOpTokenValidator.groovy
@@ -13,9 +13,9 @@ class NoOpTokenValidator implements TokenValidator {
 	@Override
 	Promise<Optional<OAuthToken>> validate(String token) {
 		if (token.contains("service")) {
-			return Promise.value(Optional.of(new OAuthToken(Optional.<User> empty(), ['service'] as Set<String>, 'fake client')))
+			return Promise.value(Optional.of(new OAuthToken(Optional.<User> empty(), ['service'] as Set<String>, 'fake client', 'faketoken')))
 		}
 		def user = Optional.of(new User("fakeUser", ["ROLE_FAKE"] as Set<String>))
-		return Promise.value(Optional.of(new OAuthToken(user, ['mobile'] as Set<String>, 'fake client')))
+		return Promise.value(Optional.of(new OAuthToken(user, ['mobile'] as Set<String>, 'fake client', 'faketoken')))
 	}
 }

--- a/ratpack-bearer-auth/src/main/java/st/ratpack/auth/OAuthToken.java
+++ b/ratpack-bearer-auth/src/main/java/st/ratpack/auth/OAuthToken.java
@@ -8,14 +8,16 @@ public class OAuthToken {
 	private Optional<User> user = Optional.empty();
 	private Set<String> scopes;
 	private String clientId;
+	private String authToken;
 
 	public OAuthToken() {
 	}
 
-	public OAuthToken(Optional<User> user, Set<String> scopes, String clientId) {
+	public OAuthToken(Optional<User> user, Set<String> scopes, String clientId, String authToken) {
 		this.user = user;
 		this.scopes = scopes;
 		this.clientId = clientId;
+		this.authToken = authToken;
 	}
 
 	public Optional<User> getUser() {
@@ -41,4 +43,8 @@ public class OAuthToken {
 	public void setClientId(String clientId) {
 		this.clientId = clientId;
 	}
+
+	public String getAuthToken() { return authToken; }
+
+	public void setAuthToken(String authToken) { this.authToken = authToken; }
 }

--- a/ratpack-bearer-auth/src/main/java/st/ratpack/auth/springsec/SpringSecCheckTokenValidator.java
+++ b/ratpack-bearer-auth/src/main/java/st/ratpack/auth/springsec/SpringSecCheckTokenValidator.java
@@ -65,6 +65,7 @@ public class SpringSecCheckTokenValidator implements TokenValidator {
 
 							oAuthToken.setClientId(tokenResponse.getClient_id());
 							oAuthToken.setScopes(tokenResponse.getScope());
+							oAuthToken.setAuthToken(token);
 
 							if (tokenResponse.getUser_name() != null && !(tokenResponse.getUser_name().isEmpty())) {
 								//There is a use so we add an optional user to the token. This won't be there in the case of a client only oauth token.

--- a/ratpack-bearer-auth/src/test/groovy/st/ratpack/auth/OAuthTokenSpec.groovy
+++ b/ratpack-bearer-auth/src/test/groovy/st/ratpack/auth/OAuthTokenSpec.groovy
@@ -1,0 +1,23 @@
+package st.ratpack.auth
+
+import spock.lang.Specification
+
+class OAuthTokenSpec extends Specification {
+
+	def 'OAuthToken constructor builds valid OAuthToken'() {
+		given:
+		Optional<User> user = Optional.of(new User())
+		Set scopes = ['mobile'] as Set
+		String clientId = 'clientId'
+		String authToken = 'authToken'
+
+		when:
+		OAuthToken token = new OAuthToken(user, scopes, clientId, authToken)
+
+		then:
+		assert token.user == user
+		assert token.scopes == scopes
+		assert token.clientId == clientId
+		assert token.authToken == authToken
+	}
+}

--- a/ratpack-bearer-auth/src/test/groovy/st/ratpack/auth/SpringSecCheckTokenValidatorSpec.groovy
+++ b/ratpack-bearer-auth/src/test/groovy/st/ratpack/auth/SpringSecCheckTokenValidatorSpec.groovy
@@ -48,6 +48,7 @@ class SpringSecCheckTokenValidatorSpec extends Specification {
 			returnedToken.user.get().username == "beckje01"
 			returnedToken.scopes.contains("read")
 			returnedToken.clientId == 'clientapp'
+			returnedToken.authToken == 'fakeToken'
 		}
 
 	}


### PR DESCRIPTION
 It would be useful to be able to get the oAuthToken string from the OAuthToken class, especially when a service needs to use an oauth token string to connect to other services.
