### PR TITLE
return 403-forbidden instead of 401-unauthorized on scope failure

### DIFF
--- a/ratpack-bearer-auth/src/main/java/st/ratpack/auth/handler/TokenScopeFilterHandler.java
+++ b/ratpack-bearer-auth/src/main/java/st/ratpack/auth/handler/TokenScopeFilterHandler.java
@@ -26,15 +26,15 @@ public class TokenScopeFilterHandler implements Handler {
 			if (!sharedScopes.isEmpty()) {
 				ctx.next();
 			} else {
-				sendError(ctx);
+				sendError(ctx, 403);
 			}
 		} else {
-			sendError(ctx);
+			sendError(ctx, 401);
 		}
 	}
 
-	private void sendError(Context ctx) {
+	private void sendError(Context ctx, int statusCode) {
 		//Not authorized stop the chain here
-		ctx.getResponse().status(401).send();
+		ctx.getResponse().status(statusCode).send();
 	}
 }

--- a/ratpack-bearer-auth/src/test/groovy/st/ratpack/auth/handler/TokenScopeFilterHandlerSpec.groovy
+++ b/ratpack-bearer-auth/src/test/groovy/st/ratpack/auth/handler/TokenScopeFilterHandlerSpec.groovy
@@ -1,6 +1,5 @@
 package st.ratpack.auth.handler
 
-import com.google.common.collect.ImmutableSet
 import spock.lang.Specification
 import spock.lang.Unroll
 import st.ratpack.auth.DefaultOAuthToken
@@ -26,6 +25,7 @@ class TokenScopeFilterHandlerSpec extends Specification {
 
 		then:
 		result.calledNext == calledNext
+		result.status.code == calledNext ? 200 : 403
 
 		where:
 		scopes              | tokenScopes           || calledNext


### PR DESCRIPTION
This will make the status codes consistent with dropwizard: https://github.com/SmartThingsOSS/dropwizard-common/blob/master/dropwizard-oauth/src/main/java/smartthings/dw/oauth/scope/ScopesAllowedDynamicFeature.java#L66

Also see: https://en.wikipedia.org/wiki/HTTP_403#Difference_from_status_.22401_Unauthorized.22

@charliek @beckje01 
