### PR TITLE
Added Principal to OAuthToken

### DIFF
--- a/ratpack-bearer-auth/src/main/java/st/ratpack/auth/DefaultOAuthToken.java
+++ b/ratpack-bearer-auth/src/main/java/st/ratpack/auth/DefaultOAuthToken.java
@@ -40,6 +40,17 @@ public class DefaultOAuthToken implements OAuthToken {
 	}
 
 	@Override
+	public String getName() {
+		if (additionalInformation.containsKey("principal")) {
+			return (String) additionalInformation.get("principal");
+		} else if (isUserToken()) {
+			return (String)additionalInformation.get("user_name");
+		} else {
+			return null;
+		}
+	}
+
+	@Override
 	public String toString() {
 		return "DefaultOAuthToken{" +
 				"clientId='" + clientId + '\'' +

--- a/ratpack-bearer-auth/src/main/java/st/ratpack/auth/OAuthToken.java
+++ b/ratpack-bearer-auth/src/main/java/st/ratpack/auth/OAuthToken.java
@@ -1,10 +1,11 @@
 package st.ratpack.auth;
 
+import java.security.Principal;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-public interface OAuthToken {
+public interface OAuthToken extends Principal {
 
 	Set<String> getScope();
 
@@ -16,6 +17,8 @@ public interface OAuthToken {
 
 	default boolean isUserToken() {
 		Map<String, Object> info = getAdditionalInformation();
-		return info != null &&info.containsKey("user_name");
+		return info != null && info.containsKey("user_name");
 	}
+
+
 }

--- a/ratpack-bearer-auth/src/main/java/st/ratpack/auth/handler/BearerTokenAuthHandler.java
+++ b/ratpack-bearer-auth/src/main/java/st/ratpack/auth/handler/BearerTokenAuthHandler.java
@@ -42,7 +42,7 @@ public class BearerTokenAuthHandler implements Handler {
 							registrySpec.add(authToken);
 
 							if (authToken.isUserToken()) {
-								DefaultUser.Builder  builder = new DefaultUser.Builder(authToken);
+								DefaultUser.Builder builder = new DefaultUser.Builder(authToken);
 								User user = builder.build();
 								registrySpec.add(user);
 							}

--- a/ratpack-bearer-auth/src/test/groovy/st/ratpack/auth/DefaultOAuthTokenSpec.groovy
+++ b/ratpack-bearer-auth/src/test/groovy/st/ratpack/auth/DefaultOAuthTokenSpec.groovy
@@ -2,6 +2,8 @@ package st.ratpack.auth
 
 import spock.lang.Specification
 
+import java.security.Principal
+
 class DefaultOAuthTokenSpec extends Specification {
 
 	void 'it should build a valid token from a constructor'() {
@@ -95,5 +97,61 @@ class DefaultOAuthTokenSpec extends Specification {
 		assert token.scope == result.scope
 		assert token.additionalInformation == result.additionalInformation
 		assert token.isUserToken()
+	}
+
+	void 'it should use "principal" as Principal if available'() {
+		given:
+		Set scopes = ['mobile'] as Set
+		String clientId = 'clientId'
+		String authToken = 'authToken'
+		Map<String, Object> additionalInfo = ['user_name': 'batman', 'principal': 'mrwayne']
+
+		OAuthToken token =
+				new DefaultOAuthToken.Builder()
+						.setAuthToken(authToken)
+						.setClientId(clientId)
+						.setScope(scopes)
+						.setAdditionalInformation(additionalInfo)
+						.build()
+
+		when:
+		OAuthToken result = new DefaultOAuthToken.Builder(token).build()
+
+		then:
+		assert token.clientId == result.clientId
+		assert token.value == result.value
+		assert token.scope == result.scope
+		assert token.additionalInformation == result.additionalInformation
+		assert token.isUserToken()
+		assert token.name == token.additionalInformation['principal']
+		assert token instanceof Principal
+	}
+
+	void 'it should use "user_name" as Principal if "principal" is unavailable'() {
+		given:
+		Set scopes = ['mobile'] as Set
+		String clientId = 'clientId'
+		String authToken = 'authToken'
+		Map<String, Object> additionalInfo = ['user_name': 'batman']
+
+		OAuthToken token =
+				new DefaultOAuthToken.Builder()
+						.setAuthToken(authToken)
+						.setClientId(clientId)
+						.setScope(scopes)
+						.setAdditionalInformation(additionalInfo)
+						.build()
+
+		when:
+		OAuthToken result = new DefaultOAuthToken.Builder(token).build()
+
+		then:
+		assert token.clientId == result.clientId
+		assert token.value == result.value
+		assert token.scope == result.scope
+		assert token.additionalInformation == result.additionalInformation
+		assert token.isUserToken()
+		assert token.name == token.additionalInformation['user_name']
+		assert token instanceof Principal
 	}
 }


### PR DESCRIPTION
This is a simple shortcut to prevent applications from needing to know what piece of additionalInformation should be considered the Principal. This mirrors functionality in dropwizard-oauth.