### PR TITLE
Provide mechanism for swapping out the method for fetching the token

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 slf4jVersion=1.7.12
 groovyVersion=2.4.4
-ratpackVersion=1.0.0
+ratpackVersion=1.4.4

--- a/ratpack-bearer-auth/src/main/java/st/ratpack/auth/TokenProvider.java
+++ b/ratpack-bearer-auth/src/main/java/st/ratpack/auth/TokenProvider.java
@@ -1,0 +1,8 @@
+package st.ratpack.auth;
+
+import ratpack.exec.Promise;
+import ratpack.http.client.ReceivedResponse;
+
+public interface TokenProvider {
+	Promise<ReceivedResponse> checkToken(String token);
+}

--- a/ratpack-bearer-auth/src/main/java/st/ratpack/auth/handler/BearerTokenAuthHandler.java
+++ b/ratpack-bearer-auth/src/main/java/st/ratpack/auth/handler/BearerTokenAuthHandler.java
@@ -1,6 +1,5 @@
 package st.ratpack.auth.handler;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import ratpack.exec.Promise;
 import ratpack.handling.Context;

--- a/ratpack-bearer-auth/src/main/java/st/ratpack/auth/springsec/SpringSecCheckTokenProvider.java
+++ b/ratpack-bearer-auth/src/main/java/st/ratpack/auth/springsec/SpringSecCheckTokenProvider.java
@@ -1,0 +1,52 @@
+package st.ratpack.auth.springsec;
+
+import com.google.inject.Inject;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import ratpack.exec.Promise;
+import ratpack.http.HttpUrlBuilder;
+import ratpack.http.client.HttpClient;
+import ratpack.http.client.ReceivedResponse;
+import st.ratpack.auth.TokenProvider;
+
+import java.net.URI;
+import java.util.Base64;
+
+public class SpringSecCheckTokenProvider implements TokenProvider {
+
+	private final HttpClient httpClient;
+	private final SpringSecCheckAuthModule.Config config;
+
+	@Inject
+	public SpringSecCheckTokenProvider(
+		HttpClient httpClient,
+		SpringSecCheckAuthModule.Config config
+	) {
+		this.httpClient = httpClient;
+		this.config = config;
+	}
+
+	@Override
+	public Promise<ReceivedResponse> checkToken(String token) {
+
+		URI uri = HttpUrlBuilder.base(config.getHost())
+			.path("oauth/check_token")
+			.params("token", token)
+			.build();
+
+		return httpClient.get(uri, rs -> {
+			rs.redirects(0);
+			rs.headers(headers -> {
+				headers.add(
+					HttpHeaderNames.AUTHORIZATION,
+					buildBasicAuthHeader(config.getUser(), config.getPassword())
+				);
+				headers.add(HttpHeaderNames.ACCEPT, "application/json");
+			});
+		});
+	}
+
+	private String buildBasicAuthHeader(String user, String password) {
+		String encodedCreds = Base64.getEncoder().encodeToString((user + ":" + password).getBytes());
+		return "Basic " + encodedCreds;
+	}
+}

--- a/ratpack-bearer-auth/src/main/java/st/ratpack/auth/springsec/SpringSecCheckTokenValidator.java
+++ b/ratpack-bearer-auth/src/main/java/st/ratpack/auth/springsec/SpringSecCheckTokenValidator.java
@@ -6,55 +6,36 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import io.netty.handler.codec.http.HttpHeaderNames;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ratpack.exec.Promise;
-import ratpack.http.HttpUrlBuilder;
-import ratpack.http.client.HttpClient;
 import ratpack.http.client.ReceivedResponse;
 import st.ratpack.auth.DefaultOAuthToken;
 import st.ratpack.auth.OAuthToken;
+import st.ratpack.auth.TokenProvider;
 import st.ratpack.auth.TokenValidator;
-
-import java.net.URI;
-import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
 public class SpringSecCheckTokenValidator implements TokenValidator {
-
-	private static final TypeReference<HashMap<String, Object>> mapTypeRef = new TypeReference<HashMap<String, Object>>() {};
-	private final HttpClient httpClient;
-	private final SpringSecCheckAuthModule.Config config;
 	private static Logger logger = LoggerFactory.getLogger(SpringSecCheckTokenValidator.class);
+	private static final TypeReference<HashMap<String, Object>> mapTypeRef = new TypeReference<HashMap<String, Object>>() {};
+
+	private final TokenProvider tokenProvider;
 	private final ObjectMapper objectMapper;
 
-	public SpringSecCheckTokenValidator(SpringSecCheckAuthModule.Config config, HttpClient httpClient) {
-		this.httpClient = httpClient;
-		this.config = config;
+	public SpringSecCheckTokenValidator(TokenProvider tokenProvider) {
+		this.tokenProvider = tokenProvider;
 		this.objectMapper = buildObjectMapper();
 	}
 
 	@Override
 	public Promise<Optional<OAuthToken>> validate(String token) {
 
-		URI uri = HttpUrlBuilder.base(config.getHost())
-			.path("oauth/check_token")
-			.params("token", token)
-			.build();
+		Promise<ReceivedResponse> resp = tokenProvider.checkToken(token);
 
-		Promise<ReceivedResponse> resp = httpClient.get(uri, rs -> {
-			rs.redirects(0);
-			rs.headers(headers -> {
-				headers.add(HttpHeaderNames.AUTHORIZATION, buildBasicAuthHeader(config.getUser(), config.getPassword()));
-				headers.add(HttpHeaderNames.ACCEPT, "application/json");
-			});
-		});
-
-		return Promise.of(downstream ->
+		return Promise.async(downstream ->
 			resp.onError(t -> {
 				logger.error("Failed to check auth token.", t);
 				downstream.success(Optional.<OAuthToken>empty());
@@ -86,14 +67,9 @@ public class SpringSecCheckTokenValidator implements TokenValidator {
 		);
 	}
 
-	private String buildBasicAuthHeader(String user, String password) {
-		String encodedCreds = Base64.getEncoder().encodeToString((user + ":" + password).getBytes());
-		return "Basic " + encodedCreds;
-	}
-
 	private static ObjectMapper buildObjectMapper() {
 		ObjectMapper objectMapper = new ObjectMapper();
-		objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES);
+		objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
 		objectMapper.getFactory().enable(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES);
 		objectMapper.getFactory().enable(JsonParser.Feature.ALLOW_SINGLE_QUOTES);
 		objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);

--- a/ratpack-bearer-auth/src/test/groovy/st/ratpack/auth/BearerTokenAuthHandlerSpec.groovy
+++ b/ratpack-bearer-auth/src/test/groovy/st/ratpack/auth/BearerTokenAuthHandlerSpec.groovy
@@ -22,7 +22,6 @@ class BearerTokenAuthHandlerSpec extends Specification {
 
 		where:
 		authHeader << [
-			null,
 			"",
 			"Basic BLAH",
 			"Bearer Token Something"

--- a/ratpack-bearer-auth/src/test/groovy/st/ratpack/auth/SpringSecCheckTokenValidatorSpec.groovy
+++ b/ratpack-bearer-auth/src/test/groovy/st/ratpack/auth/SpringSecCheckTokenValidatorSpec.groovy
@@ -10,6 +10,7 @@ import spock.lang.Shared
 import spock.lang.Specification
 import st.fixture.SpringSecCheckTokenStub
 import st.ratpack.auth.springsec.SpringSecCheckAuthModule
+import st.ratpack.auth.springsec.SpringSecCheckTokenProvider
 import st.ratpack.auth.springsec.SpringSecCheckTokenValidator
 
 class SpringSecCheckTokenValidatorSpec extends Specification {
@@ -24,10 +25,12 @@ class SpringSecCheckTokenValidatorSpec extends Specification {
 		given:
 		def conf = new SpringSecCheckAuthModule.Config(host: springSec.getAddress(), user: "fake", password: "pass")
 		def httpClientToSpringSec
+		TokenProvider tokenProvider
 		TokenValidator tokenValidator
 		harness.run {
 			httpClientToSpringSec = HttpClient.httpClient(new UnpooledByteBufAllocator(false), 2000)
-			tokenValidator = new SpringSecCheckTokenValidator(conf, httpClientToSpringSec)
+			tokenProvider = new SpringSecCheckTokenProvider(httpClientToSpringSec, conf)
+			tokenValidator = new SpringSecCheckTokenValidator(tokenProvider)
 		}
 
 		when:
@@ -54,10 +57,12 @@ class SpringSecCheckTokenValidatorSpec extends Specification {
 		given:
 		def conf = new SpringSecCheckAuthModule.Config(host: springSec.getAddress(), user: "fake", password: "pass")
 		def httpClientToSpringSec
+		TokenProvider tokenProvider
 		TokenValidator tokenValidator
 		harness.run {
 			httpClientToSpringSec = HttpClient.httpClient(new UnpooledByteBufAllocator(false), 2000)
-			tokenValidator = new SpringSecCheckTokenValidator(conf, httpClientToSpringSec)
+			tokenProvider = new SpringSecCheckTokenProvider(httpClientToSpringSec, conf)
+			tokenValidator = new SpringSecCheckTokenValidator(tokenProvider)
 		}
 
 		when:


### PR DESCRIPTION
* Provides a mechanism to swap out the implementation of fetching the token.  This allows projects to override usage HttpClient with ZipkinHttpClient.

* Also, upgraded lib to Ratpack 1.4.4 just to stay current.

This change leaves the current SpringSec* impls as the defaults, but allows libraries to swap out implementations w/ syntax like in their own modules:

```
  OptionalBinder.newOptionalBinder(binder(), TokenProvider.class)
      .setBinding().to(ZipkinTokenProvider.class).in(Scopes.SINGLETON);
```