### PR TITLE
Fix to prevent caching error responses

### DIFF
--- a/ratpack-bearer-auth/src/test/groovy/st/ratpack/auth/CachingTokenValidatorSpec.groovy
+++ b/ratpack-bearer-auth/src/test/groovy/st/ratpack/auth/CachingTokenValidatorSpec.groovy
@@ -4,27 +4,31 @@ import ratpack.exec.ExecResult
 import ratpack.exec.Promise
 import ratpack.test.exec.ExecHarness
 import spock.lang.AutoCleanup
+import spock.lang.Shared
 import spock.lang.Specification
+import spock.lang.Unroll
 import st.ratpack.auth.internal.DefaultOAuthToken
 
 class CachingTokenValidatorSpec extends Specification {
 
 	@AutoCleanup
 	ExecHarness harness = ExecHarness.harness()
+	TokenValidator tokenValidator = Mock()
+	CachingTokenValidator cachingTokenValidator = new CachingTokenValidator(tokenValidator)
+	@Shared
+	ValidateTokenResult validTokenResult = ValidateTokenResult.valid(Mock(OAuthToken))
+
+	def setup() {
+		0 * _
+	}
 
 	def "Caching validator only calls upstream once for a token"() {
 		given:
 		String token = "fakeToken"
 		OAuthToken oAuthToken =
 				new DefaultOAuthToken.Builder()
-					.setAuthToken(token)
-					.build()
-
-		TokenValidator tokenValidator = Mock(TokenValidator)
-		CachingTokenValidator cachingTokenValidator
-		harness.run {
-			cachingTokenValidator = new CachingTokenValidator(tokenValidator)
-		}
+						.setAuthToken(token)
+						.build()
 
 		when: "Validating a token"
 		ExecResult<ValidateTokenResult> result = harness.yield {
@@ -32,9 +36,11 @@ class CachingTokenValidatorSpec extends Specification {
 		}
 
 		then: "Calls upstream on a cache miss"
-		1 * tokenValidator.validate(token) >> Promise.<ValidateTokenResult> value(ValidateTokenResult.valid(oAuthToken))
 		result.success
 		result.value.isValid()
+
+		and:
+		1 * tokenValidator.validate(token) >> Promise.value(ValidateTokenResult.valid(oAuthToken))
 
 		when: "A second validation call happens"
 		result = harness.yield {
@@ -42,9 +48,31 @@ class CachingTokenValidatorSpec extends Specification {
 		}
 
 		then: "No More calls to upstream"
-		0 * _._
 		result.success
 		result.value.isValid()
 	}
 
+
+	@Unroll("error token results are not cached - #validateTokenResult.status")
+	def 'error token results are not cached'() {
+		given:
+		String token = UUID.randomUUID().toString()
+
+		when:
+		ValidateTokenResult result = harness.yield {
+			cachingTokenValidator.validate(token)
+		}.valueOrThrow
+
+		then:
+		result == cachedResult
+
+		and:
+		tokenValidator.validate(token) >> Promise.value(validateTokenResult)
+
+		where:
+		validateTokenResult              | cachedResult
+		ValidateTokenResult.INVALID_CASE | ValidateTokenResult.INVALID_CASE
+		ValidateTokenResult.ERROR_CASE   | null
+		validTokenResult                 | validTokenResult
+	}
 }


### PR DESCRIPTION
Error results were being cached because the mapping of error status to null was not the returned promise value:

**Original code:**
```
Promise<ValidateTokenResult> promiseOAuthToken = upstreamValidator.validate(token).cache();
promiseOAuthToken
	.onError(e -> cache.invalidate(token))
	.map(validateTokenResult -> {
		//This will ignore any error cases but allow for caching of invalid tokens
		if (validateTokenResult.isErrorResult()) {
			return null;
		} else {
			return validateTokenResult;
		}
	})
	.onNull(() -> cache.invalidate(token))
	.then(o -> logger.trace("PUTTING: {}", o));
return promiseOAuthToken;
```

We return the original promise declared at the top. The calls to `onError`, `map` and `onNull` return new promises which get executed, but ultimately discarded.

The `onError` and `onNull` calls were removed because this only gets called on a cache miss. The docs for `invalidate` also mention that calling it during a load is undefined:

> The behavior of this operation is undefined for  an entry that is being loaded and is otherwise not present.