### PR TITLE
Add ValidateTokenResult to registry on invalid tokens for RequireAuthHandler usage

### DIFF
--- a/ratpack-bearer-auth/src/main/java/st/ratpack/auth/handler/BearerTokenAuthHandler.java
+++ b/ratpack-bearer-auth/src/main/java/st/ratpack/auth/handler/BearerTokenAuthHandler.java
@@ -53,7 +53,7 @@ public class BearerTokenAuthHandler implements Handler {
 
 							}));
 						} else {
-							ctx.next();
+							ctx.next(Registry.single(validateTokenResult));
 						}
 					});
 			} else {

--- a/ratpack-bearer-auth/src/test/groovy/st/ratpack/auth/handler/BearerTokenAuthHandlerSpec.groovy
+++ b/ratpack-bearer-auth/src/test/groovy/st/ratpack/auth/handler/BearerTokenAuthHandlerSpec.groovy
@@ -27,6 +27,7 @@ class BearerTokenAuthHandlerSpec extends Specification {
 		then:
 		1 * tokenValidator.validate("Token") >> Promise.value(ValidateTokenResult.valid(oAuthToken))
 		result.getRegistry().maybeGet(OAuthToken).present
+		result.getRegistry().maybeGet(ValidateTokenResult).present
 		result.calledNext
 	}
 
@@ -39,6 +40,7 @@ class BearerTokenAuthHandlerSpec extends Specification {
 
 		then:
 		!result.getRegistry().maybeGet(OAuthToken).present
+		!result.getRegistry().maybeGet(ValidateTokenResult).present
 		result.calledNext
 
 		where:
@@ -62,6 +64,7 @@ class BearerTokenAuthHandlerSpec extends Specification {
 		1 * tokenValidator.validate("Token") >> Promise.value(ValidateTokenResult.INVALID_CASE)
 
 		!result.getRegistry().maybeGet(OAuthToken).present
+		result.getRegistry().maybeGet(ValidateTokenResult).present
 		result.calledNext
 	}
 }


### PR DESCRIPTION
Currently invalid token results are not being added to the registry and `RequireAuthHandler` is returning 401 on 5xx oauth errors since it can't find a `ValidateTokenResult`.