### PR TITLE
Provide more flexible token validator mocking

### DIFF
--- a/ratpack-bearer-auth-test/src/main/groovy/st/fixture/NoOpTokenValidator.groovy
+++ b/ratpack-bearer-auth-test/src/main/groovy/st/fixture/NoOpTokenValidator.groovy
@@ -1,39 +1,63 @@
 package st.fixture
 
 import ratpack.exec.Promise
-import st.ratpack.auth.DefaultValidateTokenResult
+import ratpack.func.Function
+import st.ratpack.auth.OAuthToken
+import st.ratpack.auth.TokenValidator
 import st.ratpack.auth.ValidateTokenResult
 import st.ratpack.auth.internal.DefaultOAuthToken
-import st.ratpack.auth.TokenValidator
 
 /**
  * Used to circumvent token validation during testing.
  */
 class NoOpTokenValidator implements TokenValidator {
 
-	Map<String, Object> info
+	Function<String, ValidateTokenResult> validator
 
 	/**
 	 * Additional information for the validated tokens contain `user_name` and `authorities`
 	 */
 	NoOpTokenValidator() {
-		info = ['user_name': 'fakeUser', authorities: ['ROLE_FAKE']]
+		this({ token ->
+			return ValidateTokenResult.valid(buildDefaultToken(token, ['user_name': 'fakeUser', authorities: ['ROLE_FAKE']]))
+		})
+	}
+
+	/**
+	 * Allows injecting custom validation logic into your tests.
+	 *
+	 * @param validator validation function
+	 */
+	NoOpTokenValidator(Function<String, ValidateTokenResult> validator) {
+		this.validator = validator
 	}
 
 	/**
 	 * Override the additional information placed into the validated tokens
 	 *
 	 * @param additionalInformation overrides the default
+	 * @deprecated As of 5.0.2, see {@link #NoOpTokenValidator(Function)}
 	 */
+	@Deprecated
 	NoOpTokenValidator(Map<String, Object> additionalInformation) {
-		info = additionalInformation ?: [:]
+		this({ token ->
+			return ValidateTokenResult.valid(buildDefaultToken(token, additionalInformation))
+		})
+	}
+
+	private static OAuthToken buildDefaultToken(String token, Map<String, Object> mobileTokenInfo) {
+		Collection<String> scopes = token.contains("service") ? ['service'] : ['mobile']
+		Map<String, Object> additionalInfo = token.contains("service") ? [:] : mobileTokenInfo
+		return new DefaultOAuthToken.Builder()
+				.setAuthToken('faketoken')
+				.setClientId('fake client')
+				.setScope(scopes)
+				.setAdditionalInformation(additionalInfo)
+				.build()
 	}
 
 	@Override
 	Promise<ValidateTokenResult> validate(String token) {
-		if (token.contains("service")) {
-			return Promise.value(ValidateTokenResult.valid(new DefaultOAuthToken('faketoken', 'fake client', ['service'] as Set<String>, [:])))
-		}
-		return Promise.value(ValidateTokenResult.valid(new DefaultOAuthToken('faketoken', 'fake client', ['mobile'] as Set<String>, info)))
+		return Promise.value(validator.apply(token))
 	}
 }

--- a/ratpack-bearer-auth-test/src/test/groovy/st/fixture/NoOpTokenValidatorSpec.groovy
+++ b/ratpack-bearer-auth-test/src/test/groovy/st/fixture/NoOpTokenValidatorSpec.groovy
@@ -1,6 +1,5 @@
 package st.fixture
 
-import ratpack.exec.ExecResult
 import ratpack.test.exec.ExecHarness
 import spock.lang.AutoCleanup
 import spock.lang.Specification
@@ -8,6 +7,7 @@ import spock.lang.Unroll
 import st.ratpack.auth.OAuthToken
 import st.ratpack.auth.TokenValidator
 import st.ratpack.auth.ValidateTokenResult
+import st.ratpack.auth.internal.DefaultOAuthToken
 
 class NoOpTokenValidatorSpec extends Specification {
 
@@ -15,24 +15,84 @@ class NoOpTokenValidatorSpec extends Specification {
 	ExecHarness harness = ExecHarness.harness()
 
 	@Unroll
-	void "it should provide a no-op validation test fixuture [ token : #token, isUserToken: #isUserToken"() {
+	def "it should provide a no-op validation test fixuture - token : #token, isUserToken: #isUserToken"() {
 		given:
 		TokenValidator validator = new NoOpTokenValidator()
 
 		when:
-		ExecResult<ValidateTokenResult> result = harness.yield {
+		ValidateTokenResult result = harness.yield {
 			return validator.validate(token)
-		}
+		}.valueOrThrow
 
 		then:
-		assert result.getValueOrThrow().isValid()
-		with(result.getValueOrThrow().getOAuthToken(), { OAuthToken token ->
-		    assert token.isUserToken() == isUserToken
+		result.isValid()
+		with(result.getOAuthToken(), { OAuthToken token ->
+			assert token.isUserToken() == isUserToken
 		})
 
 		where:
-		token     |  isUserToken
-		'service' |  false
-		'blargh'  |  true
+		token     | isUserToken
+		'service' | false
+		'blargh'  | true
+	}
+
+	@Unroll
+	def "can provide custom additional info for mobile scoped tokens only - token : #token"() {
+		given:
+		TokenValidator validator = new NoOpTokenValidator(info)
+
+		when:
+		ValidateTokenResult result = harness.yield {
+			return validator.validate(token)
+		}.valueOrThrow
+
+		then:
+		result.isValid()
+		with(result.getOAuthToken(), { OAuthToken token ->
+			assert token.isUserToken() == isUserToken
+			assert token.additionalInformation == expectedInfo
+		})
+
+		where:
+		token     | isUserToken | info                                                  | expectedInfo
+		'service' | false       | ['user_name': 'testUser', authorities: ['ROLE_TEST']] | [:]
+		'blargh'  | true        | ['user_name': 'testUser', authorities: ['ROLE_TEST']] | ['user_name': 'testUser', authorities: ['ROLE_TEST']]
+	}
+
+	def "custom validation can be injected"() {
+		given:
+		TokenValidator validator = new NoOpTokenValidator({ token ->
+			if (token.contains('test')) {
+				OAuthToken oAuthToken = new DefaultOAuthToken.Builder()
+						.setAuthToken("testtoken")
+						.setClientId("test client")
+						.setScope(['test'])
+						.setAdditionalInformation(['user_name': 'testUser', authorities: ['ROLE_TEST']])
+						.build()
+				return ValidateTokenResult.valid(oAuthToken)
+			}
+			return ValidateTokenResult.INVALID_CASE
+		})
+
+		when:
+		ValidateTokenResult result = harness.yield {
+			return validator.validate(token)
+		}.valueOrThrow
+
+		then:
+		assert result.status == status
+		if (result.isValid()) {
+			with(result.getOAuthToken(), { OAuthToken token ->
+				assert token.isUserToken()
+				assert token.value == "testtoken"
+				assert token.clientId == "test client"
+				assert token.scope.contains('test')
+			})
+		}
+
+		where:
+		token  | status
+		'test' | ValidateTokenResult.Status.VALID
+		'bad'  | ValidateTokenResult.Status.INVALID
 	}
 }


### PR DESCRIPTION
Allows you to pass in a function for mapping tokens to `ValidateTokenResult` that can suit your testing requirements. See "custom validation can be injected" test example.

Deprecated the additional info constructor because custom additional info can now be accomplished by passing in a custom mapping function.